### PR TITLE
add www to pycon.org cname

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,2 @@
 pycon.org
+www.pycon.org


### PR DESCRIPTION
this resolves the issue where www.pycon.org will not show up correctly over https