### PR TITLE
Add <title>

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: page
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title></title>
+    <title>Join us at PyCon</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
The page currently doesn't have a title attribute, so it defaults to "https://pycon.org", which is a bit silly looking. 

This PR changes the page title to match the displayed title, "Join us at PyCon"