### PR TITLE
Remove/update unused conferences

### DIFF
--- a/_national/pycon-cameroon.yml
+++ b/_national/pycon-cameroon.yml
@@ -2,5 +2,5 @@
 name: PyCon Cameroon
 flag: cm
 location: Cameroon
-website: http://pythoncm.org/pycon.html
+website: https://pythoncm.org/
 ---

--- a/_national/pycon-dk.yml
+++ b/_national/pycon-dk.yml
@@ -1,6 +1,0 @@
----
-name: PyCon DK
-flag: dk
-location: Denmark
-website: http://pycon.dk
----

--- a/_national/pycon-iran.yml
+++ b/_national/pycon-iran.yml
@@ -1,6 +1,0 @@
----
-name: PyCon Iran
-flag: ir
-location: Iran
-website: http://www.pycon.ir
----

--- a/_national/pycon-ireland.yml
+++ b/_national/pycon-ireland.yml
@@ -2,5 +2,5 @@
 name: PyCon Ireland
 flag: ie
 location: Ireland
-website: http://python.ie/pyconireland
+website: https://python.ie/
 ---

--- a/_national/pycon-sk.yml
+++ b/_national/pycon-sk.yml
@@ -1,6 +1,0 @@
----
-name: PyCon SK
-flag: sk
-location: Slovakia
-website: http://sk.pycon.org
----

--- a/_national/pycon-venezuela.yml
+++ b/_national/pycon-venezuela.yml
@@ -1,6 +1,0 @@
----
-name: PyCon Venezuela
-flag: ve
-location: Venezuela
-website: http://ve.pycon.org
----

--- a/_regional/depy.yml
+++ b/_regional/depy.yml
@@ -1,5 +1,0 @@
----
-name: DePy
-location: Chicago, Illinois, United States
-website: http://mdp.cdm.depaul.edu/DePy2016
----

--- a/_regional/pytennessee.yml
+++ b/_regional/pytennessee.yml
@@ -1,5 +1,0 @@
----
-name: PyTennessee
-location: Nashville, Tennessee, United States
-website: https://www.pytennessee.org/
----


### PR DESCRIPTION
This is not exhaustive, as I did not want to remove/update anything too controversial.

Partially fixes #15 

Cameroon: 404. Fixed by going to main page, not conference specific url
Denmark: Site used for dubious advertising. Not used for anything Python related. Removed.
Ireland: 404. Fixed by going to main page, not conference specific url
Slovakia: "Just Testing - Maxteroit". Removed.
Venezuela: Nothing on domain. Removed. (pyconve.com also dead)