### PR TITLE
Reference archival URL

### DIFF
--- a/_national/pycon-dk.yml
+++ b/_national/pycon-dk.yml
@@ -2,5 +2,5 @@
 name: PyCon DK
 flag: dk
 location: Denmark
-website: http://pycon.dk
+website:  https://web.archive.org/web/20161010045716/http://pycon.dk/
 ---


### PR DESCRIPTION
The PSF Trademarks Working Group was notified that the pycon.dk page is being cybersquatted by a commercial sales site with no relation to the Python programming language.  We suggest that referencing the last "authentic" version of the page is a good approach.  The underlying organizers may still be active, but might simply have let domain lapse.