### PR TITLE
Update online 2020-21 and announce future plans

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,14 @@ layout: page
                   </div>
                 </div>
                 <div class="conference-details">
-                  <p>PyCon 2020 will be held in Pittsburgh, Pennsylvania from April 15-23, 2020. PyCon 2018 and 2019 were held in Cleveland, OH. PyCon 2016 and 2017 were held in Portland, Oregon, USA. PyCon 2015 and 2014 were held in Montreal, Canada. PyCon 2013 and 2012 were held in Santa Clara, California. PyCon 2010 and 2011 were in Atlanta, Georgia, USA, with over 1400 people attending 2011. PyCon 2008 &amp; 2009 were in Chicago, Illinois. PyCon 2006 &amp; 2007 were held in Dallas, Texas. Washington DC hosted PyCon 2003, 2004, &amp; 2005.</p>
+                  <p>PyCon 2020 and 2021 became online events due to the Covid-19 pandemic. PyCon 2022 and 2023 will be held
+                    in Salt Lake City, UT.  PyCon will return to Pittsburgh (originally scheduled for 202-2021) for 2024 and 
+                    2025. PyCon 2018 and 2019 were held in Cleveland, OH. PyCon 2016 and 2017 were held in Portland, Oregon, 
+                    USA. PyCon 2015 and 2014 were held in Montreal, Canada. PyCon 2013 and 2012 were held in Santa Clara, 
+                    California. PyCon 2010 and 2011 were in Atlanta, Georgia, USA, with over 1400 people attending 2011. 
+                    PyCon 2008 and 2009 were in Chicago, Illinois. PyCon 2006 and 2007 were held in Dallas, Texas. 
+                    Washington DC hosted PyCon 2003, 2004, and 2005.
+                  </p>
                   <p><a href="http://us.pycon.org">Visit Website</a></p>
                 </div>
               </div>


### PR DESCRIPTION
Not related to Trademark Committee per se, but since I took a closer look, it seems like we can update the last few years, and next few, in light of the pandemic-driven changes.

An ampersand and the word 'and' were intermixed in the prior paragraph.  I have made it consistently use the word instead.