### PR TITLE
Typo and line breaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,8 +76,9 @@ layout: page
                 </div>
                 <div class="conference-details">
                   <p>PyCon 2020 and 2021 became online events due to the Covid-19 pandemic. PyCon 2022 and 2023 will be held
-                    in Salt Lake City, UT.  PyCon will return to Pittsburgh (originally scheduled for 202-2021) for 2024 and 
-                    2025. PyCon 2018 and 2019 were held in Cleveland, OH. PyCon 2016 and 2017 were held in Portland, Oregon, 
+                    in Salt Lake City, UT.  PyCon will return to Pittsburgh (originally scheduled for 2020-2021) for 2024 and 
+                    2025.</p>
+                  <p>PyCon 2018 and 2019 were held in Cleveland, OH. PyCon 2016 and 2017 were held in Portland, Oregon, 
                     USA. PyCon 2015 and 2014 were held in Montreal, Canada. PyCon 2013 and 2012 were held in Santa Clara, 
                     California. PyCon 2010 and 2011 were in Atlanta, Georgia, USA, with over 1400 people attending 2011. 
                     PyCon 2008 and 2009 were in Chicago, Illinois. PyCon 2006 and 2007 were held in Dallas, Texas. 


### PR DESCRIPTION
I made a typo (`202-2021` rather than `2020-2021`) in my earlier PR.  Looking at the rendered version, I think the paragraph has gotten long enough to warrant being split into a couple paragraphs.