### PR TITLE
Discontinued events, twitter links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,12 +20,12 @@ jobs:
       - name: setup ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
       - name: bundle install
         run: | 
           gem update --system --no-document
           gem update bundler --no-document
-          gem install jekyll bundler html-proofer
+          gem install jekyll bundler
           bundle install
       - name: build jekyll
         run: bundle exec jekyll build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         run: | 
           gem update --system --no-document
           gem update bundler --no-document
-          gem install jekyll bundler
+          gem install jekyll bundler html-proofer
           bundle install
       - name: build jekyll
         run: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source "https://rubygems.org"
 gem 'github-pages', group: :jekyll_plugins
+gem 'html-proofer'

--- a/_national/dragonpy-slovenia.yml
+++ b/_national/dragonpy-slovenia.yml
@@ -3,4 +3,5 @@ name: DragonPy
 flag: si
 location: Slovenia
 website: http://dragonpy.com/
+twitter: dragonpyconf
 ---

--- a/_national/euro-python.yml
+++ b/_national/euro-python.yml
@@ -3,4 +3,5 @@ name: Euro Python
 flag: eu
 location: Europe
 website: http://www.europython.eu
+twitter: europython
 ---

--- a/_national/kiwi-pycon.yml
+++ b/_national/kiwi-pycon.yml
@@ -3,4 +3,5 @@ name: Kiwi PyCon
 flag: nz
 location: New Zealand
 website: http://nz.pycon.org
+twitter: kiwipycon
 ---

--- a/_national/pycon-ar.yml
+++ b/_national/pycon-ar.yml
@@ -3,4 +3,5 @@ name: PyCon AR
 flag: ar
 location: Argentina
 website: http://ar.pycon.org
+twitter: pyconar
 ---

--- a/_national/pycon-au.yml
+++ b/_national/pycon-au.yml
@@ -3,4 +3,5 @@ name: PyCon AU
 flag: au
 location: Australia
 website: http://au.pycon.org
+twitter: pyconau
 ---

--- a/_national/pycon-belarus.yml
+++ b/_national/pycon-belarus.yml
@@ -2,5 +2,5 @@
 name: PyCon Belarus
 flag: by
 location: Belarus
-website: http://by.pycon.org
+website: https://web.archive.org/web/20210214080804/https://by.pycon.org/
 ---

--- a/_national/pycon-belarus.yml
+++ b/_national/pycon-belarus.yml
@@ -3,4 +3,5 @@ name: PyCon Belarus
 flag: by
 location: Belarus
 website: https://web.archive.org/web/20210214080804/https://by.pycon.org/
+twitter: pyconby
 ---

--- a/_national/pycon-bolivia.yml
+++ b/_national/pycon-bolivia.yml
@@ -3,4 +3,5 @@ name: PyCon Bolivia
 flag: bo
 location: Bolivia
 website: http://pycon.bo/
+twitter: pyconbolivia
 ---

--- a/_national/pycon-canada.yml
+++ b/_national/pycon-canada.yml
@@ -3,4 +3,5 @@ name: PyCon Canada
 flag: ca
 location: Canada
 website: http://www.pycon.ca
+twitter: pyconca
 ---

--- a/_national/pycon-china.yml
+++ b/_national/pycon-china.yml
@@ -3,4 +3,5 @@ name: PyCon China
 flag: cn
 location: China
 website: http://cn.pycon.org
+twitter: PyConChina
 ---

--- a/_national/pycon-colombia.yml
+++ b/_national/pycon-colombia.yml
@@ -3,4 +3,5 @@ name: PyCon Colombia
 flag: co
 location: Colombia
 website: https://www.pycon.co/
+twitter: pyconcolombia
 ---

--- a/_national/pycon-cz.yml
+++ b/_national/pycon-cz.yml
@@ -3,4 +3,5 @@ name: PyCon CZ
 flag: cz
 location: Czech Republic
 website: http://cz.pycon.org
+twitter: pyconcz
 ---

--- a/_national/pycon-finland.yml
+++ b/_national/pycon-finland.yml
@@ -2,5 +2,7 @@
 name: PyCon Finland
 flag: fi
 location: Finland
+discontinued: true
 website: http://fi.pycon.org
+twitter: pyconfinland
 ---

--- a/_national/pycon-fr.yml
+++ b/_national/pycon-fr.yml
@@ -3,4 +3,5 @@ name: PyCon FR
 flag: fr
 location: France
 website: http://fr.pycon.org
+twitter: pyconfr
 ---

--- a/_national/pycon-hk.yml
+++ b/_national/pycon-hk.yml
@@ -3,4 +3,5 @@ name: PyCon HK
 flag: hk
 location: Hong Kong
 website: http://www.pycon.hk
+twitter: pyconhk
 ---

--- a/_national/pycon-india.yml
+++ b/_national/pycon-india.yml
@@ -3,4 +3,5 @@ name: PyCon India
 flag: in
 location: India
 website: http://in.pycon.org
+twitter: pyconindia
 ---

--- a/_national/pycon-iran.yml
+++ b/_national/pycon-iran.yml
@@ -3,5 +3,5 @@ name: PyCon Iran
 flag: ir
 discontinued: true
 location: Iran
-website: http://www.pycon.ir
+website: https://web.archive.org/web/20210303120107/http://pycon.ir/
 ---

--- a/_national/pycon-israel.yml
+++ b/_national/pycon-israel.yml
@@ -3,4 +3,5 @@ name: Pycon Israel
 flag: il
 location: Israel
 website: http://il.pycon.org
+twitter: pyconil
 ---

--- a/_national/pycon-italia.yml
+++ b/_national/pycon-italia.yml
@@ -3,4 +3,5 @@ name: PyCon Italia
 flag: it
 location: Italy
 website: http://www.pycon.it
+twitter: pyconit
 ---

--- a/_national/pycon-jp.yml
+++ b/_national/pycon-jp.yml
@@ -3,4 +3,5 @@ name: PyCon JP
 flag: jp
 location: Japan
 website: https://pycon.jp/
+twitter: pyconjapan
 ---

--- a/_national/pycon-korea.yml
+++ b/_national/pycon-korea.yml
@@ -3,4 +3,5 @@ name: PyCon Korea
 flag: kr
 location: South Korea
 website: http://www.pycon.kr
+twitter: PyConKR
 ---

--- a/_national/pycon-latam.yml
+++ b/_national/pycon-latam.yml
@@ -3,4 +3,5 @@ name: PyCon Latam
 flag: mx
 location: Puerto Vallarta, México
 website: https://www.pylatam.org/en/
+twitter: PyLatam
 ---

--- a/_national/pycon-lt.yml
+++ b/_national/pycon-lt.yml
@@ -3,4 +3,5 @@ name: PyCon LT
 flag: lt
 location: Lithuania
 website: http://pycon.lt
+twitter: PyConLT
 ---

--- a/_national/pycon-my.yml
+++ b/_national/pycon-my.yml
@@ -3,4 +3,5 @@ name: PyCon MY
 flag: my
 location: Malaysia
 website: http://www.pycon.my
+twitter: pyconmy
 ---

--- a/_national/pycon-nigeria.yml
+++ b/_national/pycon-nigeria.yml
@@ -3,4 +3,5 @@ name: PyCon Nigeria
 flag: ng
 location: Nigeria
 website: https://web.archive.org/web/20210124204511/http://pythonnigeria.org/pycon/
+twitter: pyconnigeria
 ---

--- a/_national/pycon-nigeria.yml
+++ b/_national/pycon-nigeria.yml
@@ -2,5 +2,5 @@
 name: PyCon Nigeria
 flag: ng
 location: Nigeria
-website: http://pycon.pythonnigeria.org/
+website: https://web.archive.org/web/20210124204511/http://pythonnigeria.org/pycon/
 ---

--- a/_national/pycon-pakistan.yml
+++ b/_national/pycon-pakistan.yml
@@ -1,6 +1,8 @@
 ---
 name: Pycon Pakistan
 flag: pk
+discontinued: true
 location: Pakistan
-website: http://pycon.pk/
+website: https://web.archive.org/web/20170908182753/http://pk.python.org:80/
+twitter: PyConPK
 ---

--- a/_national/pycon-ph.yml
+++ b/_national/pycon-ph.yml
@@ -3,4 +3,5 @@ name: Pycon PH
 flag: ph
 location: Philippines
 website: http://ph.pycon.org
+twitter: pyconph
 ---

--- a/_national/pycon-pl.yml
+++ b/_national/pycon-pl.yml
@@ -3,4 +3,5 @@ name: PyCon PL
 flag: pl
 location: Poland
 website: http://pl.pycon.org
+twitter: pyconpl
 ---

--- a/_national/pycon-russia.yml
+++ b/_national/pycon-russia.yml
@@ -3,4 +3,5 @@ name: PyCon Russia
 flag: ru
 location: Russia
 website: http://pycon.ru
+twitter: PyConRu
 ---

--- a/_national/pycon-singapore.yml
+++ b/_national/pycon-singapore.yml
@@ -3,4 +3,5 @@ name: PyCon Singapore
 flag: sg
 location: Singapore
 website: https://pycon.sg
+twitter: pyconsg
 ---

--- a/_national/pycon-sk.yml
+++ b/_national/pycon-sk.yml
@@ -1,7 +1,7 @@
 ---
 name: PyCon SK
 flag: sk
-discontinued: true
 location: Slovakia
-website: https://web.archive.org/web/20190810123123/https://2019.pycon.sk/en/
+website: https://pycon.sk/
+twitter: pyconsk
 ---

--- a/_national/pycon-sk.yml
+++ b/_national/pycon-sk.yml
@@ -3,5 +3,5 @@ name: PyCon SK
 flag: sk
 discontinued: true
 location: Slovakia
-website: http://sk.pycon.org
+website: https://web.archive.org/web/20190810123123/https://2019.pycon.sk/en/
 ---

--- a/_national/pycon-sweden.yml
+++ b/_national/pycon-sweden.yml
@@ -3,4 +3,5 @@ name: PyCon Sweden
 flag: se
 location: Sweden
 website: http://www.pycon.se
+twitter: pyconse
 ---

--- a/_national/pycon-taiwan.yml
+++ b/_national/pycon-taiwan.yml
@@ -3,4 +3,5 @@ name: PyCon Taiwan
 flag: tw
 location: Taiwan
 website: http://tw.pycon.org
+twitter: PyConTW
 ---

--- a/_national/pycon-thailand.yml
+++ b/_national/pycon-thailand.yml
@@ -3,4 +3,5 @@ name: PyCon Thailand
 flag: th
 location: Thailand
 website: http://th.pycon.org/
+twitter: pyconthailand
 ---

--- a/_national/pycon-thailand.yml
+++ b/_national/pycon-thailand.yml
@@ -2,5 +2,5 @@
 name: PyCon Thailand
 flag: th
 location: Thailand
-website: https://th.pycon.org/en/
+website: http://th.pycon.org/
 ---

--- a/_national/pycon-turkey.yml
+++ b/_national/pycon-turkey.yml
@@ -3,4 +3,5 @@ name: PyCon Turkey
 flag: tr
 location: Turkey
 website: https://tr.pycon.org/
+twitter: pycontr
 ---

--- a/_national/pycon-uk.yml
+++ b/_national/pycon-uk.yml
@@ -3,4 +3,5 @@ name: PyCon UK
 flag: gb
 location: United Kingdom
 website: http://pyconuk.org
+twitter: PyConUK
 ---

--- a/_national/pycon-ukraine.yml
+++ b/_national/pycon-ukraine.yml
@@ -3,4 +3,5 @@ name: PyCon Ukraine
 flag: ua
 location: Ukraine
 website: http://ua.pycon.org
+twitter: uapycon
 ---

--- a/_national/pycon-uruguay.yml
+++ b/_national/pycon-uruguay.yml
@@ -1,6 +1,8 @@
 ---
 name: PyCon Uruguay
 flag: uy
+discontinued: true
 location: Uruguay
-website: https://python.uy/
+website: https://web.archive.org/web/20130521223448/http://uy.pycon.org/
+twitter: uapycon
 ---

--- a/_national/pycon-venezuela.yml
+++ b/_national/pycon-venezuela.yml
@@ -3,5 +3,5 @@ name: PyCon Venezuela
 flag: ve
 discontinued: true
 location: Venezuela
-website: http://ve.pycon.org
+website: http://web.archive.org/web/20131019013436/http://ve.pycon.org/
 ---

--- a/_national/pycon-venezuela.yml
+++ b/_national/pycon-venezuela.yml
@@ -4,4 +4,5 @@ flag: ve
 discontinued: true
 location: Venezuela
 website: http://web.archive.org/web/20131019013436/http://ve.pycon.org/
+twitter: PyConVE
 ---

--- a/_national/pycon-za.yml
+++ b/_national/pycon-za.yml
@@ -3,4 +3,5 @@ name: PyCon ZA
 flag: za
 location: South Africa
 website: http://za.pycon.org
+twitter: pyconza
 ---

--- a/_national/pythonbrasil.yml
+++ b/_national/pythonbrasil.yml
@@ -3,4 +3,5 @@ name: PythonBrasil
 flag: br
 location: Brazil
 website: http://www.pythonbrasil.org.br
+twitter: pythonbrasil
 ---

--- a/_regional/depy.yml
+++ b/_regional/depy.yml
@@ -2,5 +2,5 @@
 name: DePy
 discontinued: true
 location: Chicago, Illinois, United States
-website: http://mdp.cdm.depaul.edu/DePy2016
+website: https://web.archive.org/web/20170725125219/http://mdp.cdm.depaul.edu/DePy2016
 ---

--- a/_regional/djangocon-us.yml
+++ b/_regional/djangocon-us.yml
@@ -2,4 +2,5 @@
 name: DjangoCon US
 location: San Diego, California, United States
 website: https://djangocon.us
+twitter: djangocon
 ---

--- a/_regional/euroscipy.yml
+++ b/_regional/euroscipy.yml
@@ -2,4 +2,5 @@
 name: EuroSciPy
 location: Europe
 website: http://www.euroscipy.org
+twitter: EuroSciPy
 ---

--- a/_regional/north-bay-python.yml
+++ b/_regional/north-bay-python.yml
@@ -2,4 +2,5 @@
 name: North Bay Python
 location: Petaluma (San Francisco Bay Area), California, United States
 website: https://www.northbaypython.org/
+twitter: northbaypython
 ---

--- a/_regional/pybay.yml
+++ b/_regional/pybay.yml
@@ -2,4 +2,5 @@
 name: PyBay
 location: San Francisco, CA
 website: https://pybay.com/
+twitter: py_bay
 ---

--- a/_regional/pybeach.yml
+++ b/_regional/pybeach.yml
@@ -2,4 +2,5 @@
 name: PyBeach
 location: Los Angeles, California, United States
 website: https://pybeach.org/
+twitter: PyBeachLA
 ---

--- a/_regional/pycascades.yml
+++ b/_regional/pycascades.yml
@@ -2,4 +2,5 @@
 name: PyCascades
 location: Pacific Northwest North America
 website: https://www.pycascades.com
+twitter: pycascades
 ---

--- a/_regional/pycon-apac.yml
+++ b/_regional/pycon-apac.yml
@@ -1,5 +1,6 @@
 ---
 name: PyCon APAC
-location: Asia Pacific
+location: Asia Pacific (rotating)
 website: https://pycon.my/
+twitter: pyconapac
 ---

--- a/_regional/pydata-conferences.yml
+++ b/_regional/pydata-conferences.yml
@@ -2,4 +2,5 @@
 name: PyData conferences
 location: Worldwide
 website: http://pydata.org/events/
+twitter: PyData
 ---

--- a/_regional/pygotham.yml
+++ b/_regional/pygotham.yml
@@ -2,4 +2,5 @@
 name: PyGotham
 location: New York, United States
 website: http://pygotham.org
+twitter: PyGotham
 ---

--- a/_regional/pygrunn.yml
+++ b/_regional/pygrunn.yml
@@ -1,5 +1,6 @@
-q---
+---
 name: PyGrunn
 location: Groningen, The Netherlands
 website: http://pygrunn.org/
+twitter: PyGrunn
 ---

--- a/_regional/pygrunn.yml
+++ b/_regional/pygrunn.yml
@@ -1,5 +1,5 @@
----
+q---
 name: PyGrunn
 location: Groningen, The Netherlands
-website: http://www.pygrunn.org/
+website: http://pygrunn.org/
 ---

--- a/_regional/pyohio.yml
+++ b/_regional/pyohio.yml
@@ -2,4 +2,5 @@
 name: PyOhio
 location: Ohio, United States
 website: http://pyohio.org
+twitter: PyOhio
 ---

--- a/_regional/pytennessee.yml
+++ b/_regional/pytennessee.yml
@@ -2,4 +2,5 @@
 name: PyTennessee
 location: Nashville, Tennessee, United States
 website: http://pytennessee.org/
+twitter: PyTennessee
 ---

--- a/_regional/pytennessee.yml
+++ b/_regional/pytennessee.yml
@@ -1,5 +1,5 @@
 ---
 name: PyTennessee
 location: Nashville, Tennessee, United States
-website: https://pytennessee.org/
+website: http://pytennessee.org/
 ---

--- a/_regional/pytexas.yml
+++ b/_regional/pytexas.yml
@@ -2,4 +2,5 @@
 name: PyTexas
 location: Texas, United States
 website: http://pytexas.org
+twitter: pytexas
 ---

--- a/_regional/python-unconference.yml
+++ b/_regional/python-unconference.yml
@@ -1,5 +1,7 @@
 ---
 name: Python Unconference
 location: Hamburg, Germany
+discontinued: true
 website: http://www.pyunconf.de/en/
+twitter: pyunconf
 ---

--- a/_regional/pythoncamp.yml
+++ b/_regional/pythoncamp.yml
@@ -2,4 +2,5 @@
 name: PythonCamp
 location: Cologne, Germany
 website: http://pythoncamp.de
+twitter: pythoncamp
 ---

--- a/_regional/scipy.in.yml
+++ b/_regional/scipy.in.yml
@@ -2,4 +2,5 @@
 name: SciPy.in
 location: India
 website: http://scipy.in
+twitter: SciPyIndia
 ---

--- a/_regional/scipy.yml
+++ b/_regional/scipy.yml
@@ -2,4 +2,5 @@
 name: SciPy
 location: United States
 website: http://conference.scipy.org/
+twitter: SciPyConf
 ---

--- a/css/main.css
+++ b/css/main.css
@@ -355,6 +355,14 @@ footer a {
   color: #fff;
 }
 
+.discontinued { 
+  font-style: italic;
+  float:right;
+}
+.discontinued::before { 
+  content: "(discontinued)"
+}
+
 /* ==========================================================================
    Media Queries
    ========================================================================== */

--- a/image-credits.html
+++ b/image-credits.html
@@ -69,7 +69,7 @@
       <li><a href="https://www.flickr.com/photos/104631750@N03/21989928394/in/album-72157660526258982/">Pycon2015_Oct_01-33 by Cape Town Python User Group</a></li>
       <li><a href="https://photos.google.com/share/AF1QipNLNY9JDEF46QMh7hN2ev32ewGDdAs6VHYTm70fbJUxzRhFzTDt-dIx8jN7IAlUJQ/photo/AF1QipP_W9xxdlPIHYN_Jo0nbGdVhuRfbH3rJR28Mafc?key=TU52ek9lWHozZFQ2LXVBbkY1a3FHTG95cGRSY0lR">PyConSK</a></li>
       <li><a href="https://photos.google.com/share/AF1QipOZUnjwvcSPU1Uo9bufgs0wHFMjTUl-1G4h-uJGhYVdN9kmbKjdYaEEq4f_pjqxVg/photo/AF1QipNKiwgT4MzaqLIaQzQRQpkZM4cirW4An-rWhx6j?key=OW9VMUoxYVBkM055amhiaTJxQk1WNVlLTVFBQWhR">PyCon Singapore</a></li>
-      <li><a href="http://na.pycon.org/this-was-pycon-namibia/">PyCon Namibia</a></li>
+      <li><a href="https://web.archive.org/web/20160322085640/http://na.pycon.org:80/this-was-pycon-namibia/">PyCon Namibia</a></li>
       <li><a href="https://www.flickr.com/photos/kushaldas/13953597834/in/pool-2597886@N24/">Untitled by Kushal Das</a></li>
       <li><a href="https://www.flickr.com/photos/kushaldas/13930024372/in/pool-2597886@N24/">Untitled by Kushal Das</a></li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -101,11 +101,15 @@ layout: page
                 </div>
                 <div class="conference-title">
                   <h3>{{conf.name}}</h3>
+                  {% if conf.discontinued %}<span class="discontinued"></span>{%endif%}
                   <p class="location">{{conf.location}}</p>
                 </div>
               </div>
               <div class="conference-details">
-                <p><a href="{{conf.website}}">Visit Website</a></p>
+                <p>
+                  <a href="{{conf.website}}">Visit{% if conf.website contains "web.archive.org" %} Archived{% endif %} Website</a>
+                  {% if conf.twitter %}<a href="https://twitter.com/{{conf.twitter}}">Follow on Twitter</a>{% endif %}
+                </p>
               </div>
             </div>
           </div>
@@ -125,11 +129,12 @@ layout: page
               <div class="conference-header">
                 <div class="conference-title">
                   <h3>{{conf.name}}</h3>
+                  {% if conf.discontinued %}<span class="discontinued"></span>{%endif%}
                   <p class="location">{{conf.location}}</p>
                 </div>
               </div>
               <div class="conference-details">
-                <p><a href="{{conf.website}}">View Website</a></p>
+                <p><a href="{{conf.website}}">View{% if conf.website contains "web.archive.org" %} Archived{% endif %} Website</a></p>
               </div>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ layout: page
               <div class="conference-details">
                 <p>
                   <a href="{{conf.website}}">Visit{% if conf.website contains "web.archive.org" %} Archived{% endif %} Website</a>
-                  {% if conf.twitter %}<a href="https://twitter.com/{{conf.twitter}}">Follow on Twitter</a>{% endif %}
+                  {% if conf.twitter %}| <a href="https://twitter.com/{{conf.twitter}}">Follow on Twitter</a>{% endif %}
                 </p>
               </div>
             </div>
@@ -134,7 +134,8 @@ layout: page
                 </div>
               </div>
               <div class="conference-details">
-                <p><a href="{{conf.website}}">View{% if conf.website contains "web.archive.org" %} Archived{% endif %} Website</a></p>
+                <p><a href="{{conf.website}}">View{% if conf.website contains "web.archive.org" %} Archived{% endif %} Website</a>
+                {% if conf.twitter %} | <a href="https://twitter.com/{{conf.twitter}}">Follow on Twitter</a>{% endif %}</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Resolves #15, #37 

Introduces new "discontinued" field to mark events as no longer running, and displays "Archived" if URLs are from web.archive.org. 

Also adds Twitter links for known events. 