### PR TITLE
Add new entry for PyCon Ghana

### DIFF
--- a/_national/pycon-gh.yml
+++ b/_national/pycon-gh.yml
@@ -1,0 +1,7 @@
+---
+name: PyCon GH
+flag: gh
+location: Ghana
+website: http://gh.pycon.org
+twitter: pyconghana
+---


### PR DESCRIPTION
The event is currently being planned: https://www.pythonghana.com/about/
The website will be online in a few weeks.

Approved by the TM committee in March 2022.