### PR TITLE
Revert "Add new entry for PyCon Ghana"

### DIFF
--- a/_national/pycon-gh.yml
+++ b/_national/pycon-gh.yml
@@ -1,7 +1,0 @@
----
-name: PyCon GH
-flag: gh
-location: Ghana
-website: http://gh.pycon.org
-twitter: pyconghana
----


### PR DESCRIPTION
Reverts PyCon/pycon.org#49

Ghana was added in #50 under a different filename, so there's a duplicate. 