### PR TITLE
Update pythonbrasil.yml

### DIFF
--- a/_national/pythonbrasil.yml
+++ b/_national/pythonbrasil.yml
@@ -1,7 +1,7 @@
 ---
-name: PythonBrasil
+name: Python Brasil
 flag: br
 location: Brazil
-website: http://www.pythonbrasil.org.br
+website: https://pythonbrasil.org.br
 twitter: pythonbrasil
 ---


### PR DESCRIPTION
- There is a space between "Python" and "Brasil"
- Add updated link with https (www. is pointing to the 2019 website)