### PR TITLE
Update kiwi-pycon.yml

### DIFF
--- a/_national/kiwi-pycon.yml
+++ b/_national/kiwi-pycon.yml
@@ -1,7 +1,7 @@
 ---
 name: Kiwi PyCon
 flag: nz
-location: New Zealand
-website: http://nz.pycon.org
+location: Aotearoa New Zealand
+website: https://kiwipycon.nz
 twitter: kiwipycon
 ---


### PR DESCRIPTION
Kiwi PyCon's page was moved from python.nz to kiwipycon.nz last year.  kiwipycon.nz will be its permanent domain from now on. The full name of our country is Aotearoa New Zealand  Thank you, Katie! <3