### PR TITLE
Removed discontinued from PyCon pakistan & updated web URL

### DIFF
--- a/_national/pycon-pakistan.yml
+++ b/_national/pycon-pakistan.yml
@@ -1,8 +1,7 @@
 ---
-name: Pycon Pakistan
+name: PyCon Pakistan
 flag: pk
-discontinued: true
 location: Pakistan
-website: https://web.archive.org/web/20170908182753/http://pk.python.org:80/
+website: https://pycon.pk
 twitter: PyConPK
 ---


### PR DESCRIPTION
I am a member of the PyCon Pakistan team. We registered with the Python
Software Foundation in 2017 and since then we have organized three Python
conferences in Pakistan, last one in 2019.

We have begun our preparations for another Python conference, to be held in
March 2024. Currently, the details on the PSF website shows PyCon
Pakistan's status as 'discontinued'. 

I've made the required changes in the PR.
