### PR TITLE
Update the name of PyCon US (from PyCon) and date information

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,14 +75,15 @@ layout: page
                   </div>
                 </div>
                 <div class="conference-details">
-                  <p>PyCon 2020 and 2021 became online events due to the Covid-19 pandemic. PyCon 2022 and 2023 will be held
-                    in Salt Lake City, UT.  PyCon will return to Pittsburgh (originally scheduled for 2020-2021) for 2024 and 
-                    2025.</p>
-                  <p>PyCon 2018 and 2019 were held in Cleveland, OH. PyCon 2016 and 2017 were held in Portland, Oregon, 
-                    USA. PyCon 2015 and 2014 were held in Montreal, Canada. PyCon 2013 and 2012 were held in Santa Clara, 
-                    California. PyCon 2010 and 2011 were in Atlanta, Georgia, USA, with over 1400 people attending 2011. 
-                    PyCon 2008 and 2009 were in Chicago, Illinois. PyCon 2006 and 2007 were held in Dallas, Texas. 
-                    Washington DC hosted PyCon 2003, 2004, and 2005.
+                  <p>PyCon US has returned to Pittsburgh (originally scheduled for 2020-2021) for 2024 and 2025. PyCon US
+                    2026 and 2027 will be held in Long Beach, California.
+                  </p>
+                  <p>PyCon US 2022 and 2023 were held in Salt Lake City, UT. PyCon US 2020 and 2021 became online events due
+                    to the Covid-19 pandemic. PyCon US 2018 and 2019 were held in Cleveland, OH. PyCon US 2016 and 2017 were
+                    held in Portland, Oregon, USA. PyCon US 2015 and 2014 were held in Montreal, Canada. PyCon US 2013 and
+                    2012 were held in Santa Clara, California. PyCon US 2010 and 2011 were in Atlanta, Georgia, USA, with
+                    over 1400 people attending 2011. PyCon US 2008 and 2009 were in Chicago, Illinois. PyCon US 2006 and
+                    2007 were held in Dallas, Texas. Washington DC hosted PyCon US 2003, 2004, and 2005.
                   </p>
                   <p><a href="http://us.pycon.org">Visit Website</a></p>
                 </div>


### PR DESCRIPTION
- Use the correct conference name for PyCon US in the PyCon US detail section

- Update the language used for PyCon US years to reflect the current date

- Add PyCon US information for 2026 - 2027 (announced during closing remarks of PyCon US 2024)