### PR TITLE
Update DjangoCon US location to "rotating"

### DIFF
--- a/_regional/djangocon-us.yml
+++ b/_regional/djangocon-us.yml
@@ -1,6 +1,6 @@
 ---
 name: DjangoCon US
-location: San Diego, California, United States
+location: United States (rotating)
 website: https://djangocon.us
 twitter: djangocon
 ---


### PR DESCRIPTION
DjangoCon US is an event that changes location within the US. This change updates the listed location similar to two other events listed here.