### PR TITLE
Resolve htmlproofer failures in CI

### DIFF
--- a/_national/dragonpy-slovenia.yml
+++ b/_national/dragonpy-slovenia.yml
@@ -2,6 +2,6 @@
 name: DragonPy
 flag: si
 location: Slovenia
-website: http://dragonpy.com/
+website: https://dragonpy.com/
 twitter: dragonpyconf
 ---

--- a/_national/europython.yml
+++ b/_national/europython.yml
@@ -2,6 +2,6 @@
 name: EuroPython
 flag: eu
 location: Europe
-website: http://www.europython.eu
+website: https://www.europython.eu
 twitter: europython
 ---

--- a/_national/pycon-ar.yml
+++ b/_national/pycon-ar.yml
@@ -2,6 +2,6 @@
 name: PyCon AR
 flag: ar
 location: Argentina
-website: http://ar.pycon.org
+website: https://ar.pycon.org
 twitter: pyconar
 ---

--- a/_national/pycon-au.yml
+++ b/_national/pycon-au.yml
@@ -2,6 +2,6 @@
 name: PyCon AU
 flag: au
 location: Australia
-website: http://au.pycon.org
+website: https://au.pycon.org
 twitter: pyconau
 ---

--- a/_national/pycon-au.yml
+++ b/_national/pycon-au.yml
@@ -2,6 +2,6 @@
 name: PyCon AU
 flag: au
 location: Australia
-website: https://au.pycon.org
+website: https://pycon.org.au/
 twitter: pyconau
 ---

--- a/_national/pycon-bolivia.yml
+++ b/_national/pycon-bolivia.yml
@@ -2,6 +2,6 @@
 name: PyCon Bolivia
 flag: bo
 location: Bolivia
-website: http://pycon.bo/
+website: https://pycon.bo/
 twitter: pyconbolivia
 ---

--- a/_national/pycon-bolivia.yml
+++ b/_national/pycon-bolivia.yml
@@ -2,6 +2,6 @@
 name: PyCon Bolivia
 flag: bo
 location: Bolivia
-website: https://pycon.bo/
+website: https://web.archive.org/web/20211221001342/http://pycon.bo/
 twitter: pyconbolivia
 ---

--- a/_national/pycon-cameroon.yml
+++ b/_national/pycon-cameroon.yml
@@ -2,5 +2,5 @@
 name: PyCon Cameroon
 flag: cm
 location: Cameroon
-website: https://pythoncm.org/
+website: https://web.archive.org/web/20210124013855/https://pythoncm.org/
 ---

--- a/_national/pycon-canada.yml
+++ b/_national/pycon-canada.yml
@@ -2,6 +2,6 @@
 name: PyCon Canada
 flag: ca
 location: Canada
-website: http://www.pycon.ca
+website: https://www.pycon.ca
 twitter: pyconca
 ---

--- a/_national/pycon-cz.yml
+++ b/_national/pycon-cz.yml
@@ -2,6 +2,6 @@
 name: PyCon CZ
 flag: cz
 location: Czech Republic
-website: http://cz.pycon.org
+website: https://cz.pycon.org
 twitter: pyconcz
 ---

--- a/_national/pycon-de.yml
+++ b/_national/pycon-de.yml
@@ -2,6 +2,6 @@
 name: PyCon DE
 flag: de
 location: Germany
-website: http://de.pycon.org
+website: https://de.pycon.org
 twitter: pyconde
 ---

--- a/_national/pycon-dk.yml
+++ b/_national/pycon-dk.yml
@@ -3,5 +3,5 @@ name: PyCon DK
 flag: dk
 location: Denmark
 discontinued: true
-website:  https://web.archive.org/web/20161010045716/http://pycon.dk/
+website:  https://web.archive.org/web/20161010045716/https://pycon.dk/
 ---

--- a/_national/pycon-finland.yml
+++ b/_national/pycon-finland.yml
@@ -3,6 +3,6 @@ name: PyCon Finland
 flag: fi
 location: Finland
 discontinued: true
-website: https://fi.pycon.org
+website: https://web.archive.org/web/20180118144427/http://fi.pycon.org/2016/
 twitter: pyconfinland
 ---

--- a/_national/pycon-finland.yml
+++ b/_national/pycon-finland.yml
@@ -3,6 +3,6 @@ name: PyCon Finland
 flag: fi
 location: Finland
 discontinued: true
-website: http://fi.pycon.org
+website: https://fi.pycon.org
 twitter: pyconfinland
 ---

--- a/_national/pycon-fr.yml
+++ b/_national/pycon-fr.yml
@@ -2,6 +2,6 @@
 name: PyCon FR
 flag: fr
 location: France
-website: http://fr.pycon.org
+website: https://fr.pycon.org
 twitter: pyconfr
 ---

--- a/_national/pycon-ghana.yml
+++ b/_national/pycon-ghana.yml
@@ -2,6 +2,6 @@
 name: PyCon Ghana
 flag: gh
 location: Ghana
-website: http://gh.pycon.org
+website: https://gh.pycon.org
 twitter: pyconghana
 ---

--- a/_national/pycon-hk.yml
+++ b/_national/pycon-hk.yml
@@ -2,6 +2,6 @@
 name: PyCon HK
 flag: hk
 location: Hong Kong
-website: http://www.pycon.hk
+website: https://www.pycon.hk
 twitter: pyconhk
 ---

--- a/_national/pycon-india.yml
+++ b/_national/pycon-india.yml
@@ -2,6 +2,6 @@
 name: PyCon India
 flag: in
 location: India
-website: http://in.pycon.org
+website: https://in.pycon.org
 twitter: pyconindia
 ---

--- a/_national/pycon-israel.yml
+++ b/_national/pycon-israel.yml
@@ -2,6 +2,6 @@
 name: Pycon Israel
 flag: il
 location: Israel
-website: http://il.pycon.org
+website: https://il.pycon.org
 twitter: pyconil
 ---

--- a/_national/pycon-italia.yml
+++ b/_national/pycon-italia.yml
@@ -2,6 +2,6 @@
 name: PyCon Italia
 flag: it
 location: Italy
-website: http://www.pycon.it
+website: https://www.pycon.it
 twitter: pyconit
 ---

--- a/_national/pycon-korea.yml
+++ b/_national/pycon-korea.yml
@@ -2,6 +2,6 @@
 name: PyCon Korea
 flag: kr
 location: South Korea
-website: http://www.pycon.kr
+website: https://www.pycon.kr
 twitter: PyConKR
 ---

--- a/_national/pycon-lt.yml
+++ b/_national/pycon-lt.yml
@@ -2,6 +2,6 @@
 name: PyCon LT
 flag: lt
 location: Lithuania
-website: http://pycon.lt
+website: https://pycon.lt
 twitter: PyConLT
 ---

--- a/_national/pycon-my.yml
+++ b/_national/pycon-my.yml
@@ -2,6 +2,6 @@
 name: PyCon MY
 flag: my
 location: Malaysia
-website: http://www.pycon.my
+website: https://www.pycon.my
 twitter: pyconmy
 ---

--- a/_national/pycon-nigeria.yml
+++ b/_national/pycon-nigeria.yml
@@ -2,6 +2,6 @@
 name: PyCon Nigeria
 flag: ng
 location: Nigeria
-website: https://web.archive.org/web/20210124204511/http://pythonnigeria.org/pycon/
+website: https://web.archive.org/web/20210124204511/https://pythonnigeria.org/pycon/
 twitter: pyconnigeria
 ---

--- a/_national/pycon-ph.yml
+++ b/_national/pycon-ph.yml
@@ -2,6 +2,6 @@
 name: Pycon PH
 flag: ph
 location: Philippines
-website: http://ph.pycon.org
+website: https://ph.pycon.org
 twitter: pyconph
 ---

--- a/_national/pycon-pl.yml
+++ b/_national/pycon-pl.yml
@@ -2,6 +2,6 @@
 name: PyCon PL
 flag: pl
 location: Poland
-website: http://pl.pycon.org
+website: https://pl.pycon.org
 twitter: pyconpl
 ---

--- a/_national/pycon-portugal.yml
+++ b/_national/pycon-portugal.yml
@@ -2,6 +2,6 @@
 name: PyCon Portugal
 flag: pt
 location: Portugal
-website: http://pycon.pt
+website: https://pycon.pt
 twitter: PyConPT
 ---

--- a/_national/pycon-russia.yml
+++ b/_national/pycon-russia.yml
@@ -2,6 +2,6 @@
 name: PyCon Russia
 flag: ru
 location: Russia
-website: http://pycon.ru
+website: https://pycon.ru
 twitter: PyConRu
 ---

--- a/_national/pycon-sweden.yml
+++ b/_national/pycon-sweden.yml
@@ -2,6 +2,6 @@
 name: PyCon Sweden
 flag: se
 location: Sweden
-website: http://www.pycon.se
+website: https://www.pycon.se
 twitter: pyconse
 ---

--- a/_national/pycon-taiwan.yml
+++ b/_national/pycon-taiwan.yml
@@ -2,6 +2,6 @@
 name: PyCon Taiwan
 flag: tw
 location: Taiwan
-website: http://tw.pycon.org
+website: https://tw.pycon.org
 twitter: PyConTW
 ---

--- a/_national/pycon-thailand.yml
+++ b/_national/pycon-thailand.yml
@@ -2,6 +2,6 @@
 name: PyCon Thailand
 flag: th
 location: Thailand
-website: http://th.pycon.org/
+website: https://th.pycon.org/
 twitter: pyconthailand
 ---

--- a/_national/pycon-uk.yml
+++ b/_national/pycon-uk.yml
@@ -2,6 +2,6 @@
 name: PyCon UK
 flag: gb
 location: United Kingdom
-website: http://pyconuk.org
+website: https://2023.pyconuk.org
 twitter: PyConUK
 ---

--- a/_national/pycon-uk.yml
+++ b/_national/pycon-uk.yml
@@ -2,6 +2,6 @@
 name: PyCon UK
 flag: gb
 location: United Kingdom
-website: https://pyconuk.org
+website: http://pyconuk.org
 twitter: PyConUK
 ---

--- a/_national/pycon-uk.yml
+++ b/_national/pycon-uk.yml
@@ -2,6 +2,6 @@
 name: PyCon UK
 flag: gb
 location: United Kingdom
-website: http://pyconuk.org
+website: https://pyconuk.org
 twitter: PyConUK
 ---

--- a/_national/pycon-ukraine.yml
+++ b/_national/pycon-ukraine.yml
@@ -2,6 +2,6 @@
 name: PyCon Ukraine
 flag: ua
 location: Ukraine
-website: http://ua.pycon.org
+website: https://ua.pycon.org
 twitter: uapycon
 ---

--- a/_national/pycon-uruguay.yml
+++ b/_national/pycon-uruguay.yml
@@ -3,6 +3,6 @@ name: PyCon Uruguay
 flag: uy
 discontinued: true
 location: Uruguay
-website: https://web.archive.org/web/20130521223448/http://uy.pycon.org/
+website: https://web.archive.org/web/20130521223448/https://uy.pycon.org/
 twitter: uapycon
 ---

--- a/_national/pycon-venezuela.yml
+++ b/_national/pycon-venezuela.yml
@@ -3,6 +3,6 @@ name: PyCon Venezuela
 flag: ve
 discontinued: true
 location: Venezuela
-website: http://web.archive.org/web/20131019013436/http://ve.pycon.org/
+website: https://web.archive.org/web/20131019013436/https://ve.pycon.org/
 twitter: PyConVE
 ---

--- a/_national/pycon-za.yml
+++ b/_national/pycon-za.yml
@@ -2,6 +2,6 @@
 name: PyCon ZA
 flag: za
 location: South Africa
-website: http://za.pycon.org
+website: https://za.pycon.org
 twitter: pyconza
 ---

--- a/_regional/depy.yml
+++ b/_regional/depy.yml
@@ -2,5 +2,5 @@
 name: DePy
 discontinued: true
 location: Chicago, Illinois, United States
-website: https://web.archive.org/web/20170725125219/http://mdp.cdm.depaul.edu/DePy2016
+website: https://web.archive.org/web/20170725125219/https://mdp.cdm.depaul.edu/DePy2016
 ---

--- a/_regional/euroscipy.yml
+++ b/_regional/euroscipy.yml
@@ -1,6 +1,6 @@
 ---
 name: EuroSciPy
 location: Europe
-website: http://www.euroscipy.org
+website: https://www.euroscipy.org
 twitter: EuroSciPy
 ---

--- a/_regional/pycon-africa.yml
+++ b/_regional/pycon-africa.yml
@@ -1,6 +1,6 @@
 ---
 name: PyCon Africa
 location: Africa (rotating)
-website: https://pycon.africa/
+website: https://africa.pycon.org/
 twitter: pyconafrica
 ---

--- a/_regional/pycon-africa.yml
+++ b/_regional/pycon-africa.yml
@@ -1,6 +1,6 @@
 ---
 name: PyCon Africa
 location: Africa (rotating)
-website: http://pycon.africa/
+website: https://pycon.africa/
 twitter: pyconafrica
 ---

--- a/_regional/pydata-conferences.yml
+++ b/_regional/pydata-conferences.yml
@@ -1,6 +1,6 @@
 ---
 name: PyData conferences
 location: Worldwide
-website: http://pydata.org/events/
+website: https://pydata.org/events/
 twitter: PyData
 ---

--- a/_regional/pygotham.yml
+++ b/_regional/pygotham.yml
@@ -1,6 +1,6 @@
 ---
 name: PyGotham
 location: New York, United States
-website: http://pygotham.org
+website: https://pygotham.org
 twitter: PyGotham
 ---

--- a/_regional/pygrunn.yml
+++ b/_regional/pygrunn.yml
@@ -1,6 +1,6 @@
 ---
 name: PyGrunn
 location: Groningen, The Netherlands
-website: http://pygrunn.org/
+website: https://pygrunn.org/
 twitter: PyGrunn
 ---

--- a/_regional/pyohio.yml
+++ b/_regional/pyohio.yml
@@ -1,6 +1,6 @@
 ---
 name: PyOhio
 location: Ohio, United States
-website: http://pyohio.org
+website: https://pyohio.org
 twitter: PyOhio
 ---

--- a/_regional/pytennessee.yml
+++ b/_regional/pytennessee.yml
@@ -1,6 +1,6 @@
 ---
 name: PyTennessee
 location: Nashville, Tennessee, United States
-website: http://pytennessee.org/
+website: https://pytennessee.org/
 twitter: PyTennessee
 ---

--- a/_regional/pytexas.yml
+++ b/_regional/pytexas.yml
@@ -1,6 +1,6 @@
 ---
 name: PyTexas
 location: Texas, United States
-website: http://pytexas.org
+website: https://pytexas.org
 twitter: pytexas
 ---

--- a/_regional/python-unconference.yml
+++ b/_regional/python-unconference.yml
@@ -2,6 +2,6 @@
 name: Python Unconference
 location: Hamburg, Germany
 discontinued: true
-website: http://www.pyunconf.de/en/
+website: https://www.pyunconf.de/en/
 twitter: pyunconf
 ---

--- a/_regional/python-unconference.yml
+++ b/_regional/python-unconference.yml
@@ -2,6 +2,6 @@
 name: Python Unconference
 location: Hamburg, Germany
 discontinued: true
-website: https://www.pyunconf.de/en/
+website: https://web.archive.org/web/20170703234229/www.pyunconf.de/en/
 twitter: pyunconf
 ---

--- a/_regional/pythoncamp.yml
+++ b/_regional/pythoncamp.yml
@@ -1,6 +1,6 @@
 ---
 name: PythonCamp
 location: Cologne, Germany
-website: http://pythoncamp.de
+website: https://pythoncamp.de
 twitter: pythoncamp
 ---

--- a/_regional/scipy.in.yml
+++ b/_regional/scipy.in.yml
@@ -1,6 +1,6 @@
 ---
 name: SciPy.in
 location: India
-website: http://scipy.in
+website: https://scipy.in
 twitter: SciPyIndia
 ---

--- a/_regional/scipy.yml
+++ b/_regional/scipy.yml
@@ -1,6 +1,6 @@
 ---
 name: SciPy
 location: United States
-website: http://conference.scipy.org/
+website: https://conference.scipy.org/
 twitter: SciPyConf
 ---

--- a/image-credits.html
+++ b/image-credits.html
@@ -61,7 +61,7 @@
     <h1>Image Credits</h1>
     <ul>
       <li><a href="https://www.flickr.com/photos/122323654@N05/15024418586/in/photolist-oTE5cL-gMEahs-9mRAWj-8HTwo8-F2w1uF-6raSuz-2nLp8-29Veup-vwPhb-pLWPzd-4oJF58-2kaCnR-aGEPRF-euTdwd-y2csk-4dLZ5h-8HLsg4-6gr1Gt-p4zRSi-ceUe9W-maauXx-8Yo1TS-fmqtQK-7mP8om-5c9eNk-8ufh5f-u2Jjv-aTsKe6-fsYgZx-bmhGME-nx5ZvT-684cuu-aFg4fv-GGYmdt-5LQDAL-7pHHRv-5FN5Y1-4ZecUW-KHN4K-y3KHZ-8xZMw7-4ifpYY-6Ukoex-r7FnsC-6DXT1s-6nftTM-MTg6-9kxcv5-jABMTE-4csmxE">Stars by Frank Van Dijk</a></li>
-      <li><a href="http://freevectormaps.com">Map by Free Vector Maps</a></li>
+      <li><a href="https://freevectormaps.com">Map by Free Vector Maps</a></li>
       <li><a href="https://www.flickr.com/photos/onyame/13885572493/in/pool-2597886@N24/">pycon2014-22 by Andreas Schreiber</a></li>
       <li><a href="https://www.dropbox.com/s/3auo10cgfhvopt9/pyconsk1.jpg?dl=0">pyconsk1.jpg</a></li>
       <li><a href="https://www.flickr.com/photos/104631750@N03/10152903844/in/album-72157636325129645/">IMG_2266 by Cape Town Python User Group</a></li>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ layout: page
                     over 1400 people attending 2011. PyCon US 2008 and 2009 were in Chicago, Illinois. PyCon US 2006 and
                     2007 were held in Dallas, Texas. Washington DC hosted PyCon US 2003, 2004, and 2005.
                   </p>
-                  <p><a href="http://us.pycon.org">Visit Website</a></p>
+                  <p><a href="https://us.pycon.org">Visit Website</a></p>
                 </div>
               </div>
           </div>
@@ -154,14 +154,14 @@ layout: page
           <a href="https://www.google.com/calendar/ical/3haig2m9msslkpf2tn1h56nn9g%40group.calendar.google.com/public/basic.ics">Python User Group iCal Calendar</a>
         </iframe>
 
-        <p>Please note that the above calendar widget uses UTC/GMT as timezone. The calendars are also available as <a href="http://lmorillas.github.io/python_events/">map mashup</a>, iCal files (<a href="https://www.google.com/calendar/ical/j7gov1cmnqr9tvg14k621j7t5c%40group.calendar.google.com/public/basic.ics">Python Events iCal Calendar</a>, <a href="https://www.google.com/calendar/ical/3haig2m9msslkpf2tn1h56nn9g%40group.calendar.google.com/public/basic.ics">Python User Group iCal Calendar</a>) or Twitter feed (<a href="https://twitter.com/PythonEvents">@PythonEvents</a>).</p>
-        <p>Also see the <a href="http://www.python.org/community/workshops/">Conferences and Workshops page on the main Python website</a>, for more information.</p>
+        <p>Please note that the above calendar widget uses UTC/GMT as timezone. The calendars are also available as <a href="https://lmorillas.github.io/python_events/">map mashup</a>, iCal files (<a href="https://www.google.com/calendar/ical/j7gov1cmnqr9tvg14k621j7t5c%40group.calendar.google.com/public/basic.ics">Python Events iCal Calendar</a>, <a href="https://www.google.com/calendar/ical/3haig2m9msslkpf2tn1h56nn9g%40group.calendar.google.com/public/basic.ics">Python User Group iCal Calendar</a>) or Twitter feed (<a href="https://twitter.com/PythonEvents">@PythonEvents</a>).</p>
+        <p>Also see the <a href="https://www.python.org/community/workshops/">Conferences and Workshops page on the main Python website</a>, for more information.</p>
       </div>
     </section>
 
     <footer>
       <div class="container">
-        <p>Designed by <a href="http://kabucreative.com">Kabu Creative</a>, maintained by the Python Community, and hosted by the <a href="https://python.org/psf-landing">Python Software Foundation</a>. <a href="image-credits.html">Image credits</a>.</p>
+        <p>Designed by <a href="https://kabucreative.com">Kabu Creative</a>, maintained by the Python Community, and hosted by the <a href="https://python.org/psf-landing">Python Software Foundation</a>. <a href="image-credits.html">Image credits</a>.</p>
         <p>Event organiser? <a href="https://github.com/PyCon/pycon.org#adding-your-event">Add or update your event</a>.</p>
       </div>
     </footer>


### PR DESCRIPTION
Update URLs to use https instead of http

This is a bulk update to resolve almost all of the htmlproofer CI errors
(and generally to link to secure versions of websites). The remaining 7
errors reported by htmlproofer are conference-specific and relate to the
inability to validate links via libcurl, which may be due to servers not
supporting https or domains no longer resolving.

---

Update websites for a batch of conferences

These updates fall into two categories:

1. Websites of inactive conferences that no longer exist or no longer
   contain conference-related content. In these instances, I've updated
   the links to the latest relevant snapshots I could find on the
   Internet Archive.

2. Conferences whose canonical domains (as referenced by their websites
   or social media accounts) do not match the domains used here
   currently.

The last remaining htmlproofer error regards PyCon UK, whose canonical
domain is correctly listed here, but it does not respond to https
requests, and so I've reverted it back to http in this commit. This
ensures that the link is still usable but does not resolve the CI error
regarding http links.