### PR TITLE
:arrow_up: Upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: setup ruby
         uses: ruby/setup-ruby@v1
       - name: bundle install


### PR DESCRIPTION
This will remove at least one GHA warning.