### PR TITLE
Update name to PyCon Philippines

### DIFF
--- a/_national/pycon-ph.yml
+++ b/_national/pycon-ph.yml
@@ -1,5 +1,5 @@
 ---
-name: Pycon PH
+name: PyCon Philippines
 flag: ph
 location: Philippines
 website: https://ph.pycon.org


### PR DESCRIPTION
**Change:**
- Updated  the name "Pycon PH" to "PyCon Philippines" for consistency with official branding and social media usage.

![image](https://github.com/user-attachments/assets/718150ca-e791-4ae4-8eeb-5cffac6c2127)
