### PR TITLE
Add configuration file for PyCon Togo

### DIFF
--- a/_national/pycon-togo.yml
+++ b/_national/pycon-togo.yml
@@ -1,0 +1,7 @@
+---
+name: PyCon Togo
+flag: tg
+location: Togo
+website: https://pycontg.pytogo.org/
+twitter: tgpycon
+---


### PR DESCRIPTION
Hello !
I'm part of the organizing committee for the recently approved PyCon Togo. We're delighted to be hosting the first edition of this national Python conference in Togo, and we'd like it to be listed among the other PyCon events on [pycon.org]([url](url)).

This PR adds the configuration file for PyCon Togo to make it visible on the official website.

Thank you for your time and support!