### PR TITLE
Update pycon-uk.yml with persistent URL

### DIFF
--- a/_national/pycon-uk.yml
+++ b/_national/pycon-uk.yml
@@ -2,6 +2,6 @@
 name: PyCon UK
 flag: gb
 location: United Kingdom
-website: https://2025.pyconuk.org
+website: https://pyconuk.org
 twitter: PyConUK
 ---


### PR DESCRIPTION
Previously used the year-specific URL because the general PyCon UK https URL was broken. Now that's fixed and the link has been updated here so as not to need annual changes.