### PR TITLE
Pycon Senegambia 

### DIFF
--- a/_regional/pycon_senegambia.yml
+++ b/_regional/pycon_senegambia.yml
@@ -1,6 +1,0 @@
----
-name: Pycon Senegambia
-location: Banjul, The Gambia
-website: https://www.pyconsenegambia.org
-twitter: PyconSenegambia
----

--- a/_regional/pycon_senegambia.yml
+++ b/_regional/pycon_senegambia.yml
@@ -1,0 +1,6 @@
+---
+name: Pycon Senegambia
+location: Banjul, The Gambia
+website: https://www.pyconsenegambia.org
+twitter: PyconSenegambia
+---

--- a/_regional/pyconsenegambia.yml
+++ b/_regional/pyconsenegambia.yml
@@ -1,0 +1,6 @@
+---
+name: Pycon Senegambia
+location: Banjul, The Gambia
+website: https://www.pyconsenegambia.org
+twitter: PyconSenegambia
+---


### PR DESCRIPTION
PyCon Senegambia is the first Python conference uniting developers, data scientists, educators, and tech enthusiasts from The Gambia and Senegal. This regional event aims to foster cross-border collaboration, empower the local tech ecosystem, and promote the use of Python in solving real world problems. With talks, workshops, and community led sessions, PyCon Senegambia creates an inclusive space to learn, share, and build the future of technology in West Africa.

