### PR TITLE
Pycon Senegambia

### DIFF
--- a/_regional/pycon_senegambia.yml
+++ b/_regional/pycon_senegambia.yml
@@ -1,6 +1,0 @@
----
-name: Pycon Senegambia
-location: Banjul, The Gambia
-website: https://www.pyconsenegambia.org
-twitter: PyconSenegambia
----

--- a/_regional/pycon_senegambia.yml
+++ b/_regional/pycon_senegambia.yml
@@ -1,0 +1,6 @@
+---
+name: Pycon Senegambia
+location: Banjul, The Gambia
+website: https://www.pyconsenegambia.org
+twitter: PyconSenegambia
+---

--- a/_regional/pyconsenegambia.yml
+++ b/_regional/pyconsenegambia.yml
@@ -1,0 +1,6 @@
+---
+name: Pycon Senegambia
+location: Banjul, The Gambia
+website: https://www.pyconsenegambia.org
+twitter: PyconSenegambia
+---


### PR DESCRIPTION

<img width="1710" height="1112" alt="Screenshot 2025-08-03 at 12 54 12" src="https://github.com/user-attachments/assets/a96b400f-d9b4-4d4d-aebd-eea2dcb35dc5" />
 **PyCon SeneGambia** is a regional Python conference that brings together Python communities from **both The Gambia and Senegal**. The name "SeneGambia" refers to the **historical and geographic region** encompassing the two countries, emphasizing collaboration and shared culture across their borders.
