### PR TITLE
Update PyCon Ireland 2026 details

### DIFF
--- a/_national/pycon-ireland.yml
+++ b/_national/pycon-ireland.yml
@@ -2,5 +2,7 @@
 name: PyCon Ireland
 flag: ie
 location: Ireland
-website: https://python.ie
+website: https://2026.pycon.ie
+twitter: Python_Ireland
+mastodon: "@Python_Ireland@mastodon.ie"
 ---


### PR DESCRIPTION
Update PyCon Ireland entry with 2026 details:

- Update website URL to https://2026.pycon.ie (dedicated 2026 conference site)
- Add Twitter handle: Python_Ireland
- Add Mastodon handle: @Python_Ireland@mastodon.ie (mastodon.ie instance)